### PR TITLE
water_map -> alpha_map; added print methods for alpha and water tris

### DIFF
--- a/games/bk.lua
+++ b/games/bk.lua
@@ -63,7 +63,7 @@ Game = {
 		map = {0x37F2C5, 0x37F405, 0x37DAF5, 0x37E8F5},
 		struct_array_pointer = {0x382970, 0x382AB0, 0x3811A0, 0x381FA0},
 		map_model_pointer = {0x382D38, 0x382E78, 0x381568, 0x382368}, -- See Game.getVertBase()
-		water_model_pointer = {0x382D3C, 0x382E7C, 0x38156C, 0x38236C}, -- See Game.getWaterVertBase()
+		alpha_model_pointer = {0x382D3C, 0x382E7C, 0x38156C, 0x38236C}, -- See Game.getAlphaVertBase()
 		return_to_lair_enabled = {0x383A60, 0x383BC0, 0x3822A0, 0x383080},
 		game_progress_bitfield = {0x383B88, 0x383D18, 0x3823F8, 0x3831A8},
 		strict_bitfield = { 0x383BB8, 0x383D48, 0x382428, 0x3831D8},
@@ -2931,6 +2931,10 @@ function Game.getFloorObject()
 	return dereferencePointer(Game.Memory.floor_object_pointer);
 end
 
+function Game.getAlphaFloorObject()
+	return dereferencePointer(Game.Memory.floor_object_pointer) + 0x10;
+end
+
 function Game.getFloor()
 	local floorObject = Game.getFloorObject();
 	if isRDRAM(floorObject) then
@@ -3073,15 +3077,16 @@ function Game.getVertsFromModel(modelPointer)
 	end
 end
 
+-- A-Map Vert-Base
 function Game.getVertBase()
 	local mapModel = dereferencePointer(Game.Memory.map_model_pointer);
 	if isRDRAM(mapModel) then
 		return Game.getVertsFromModel(mapModel);
 	end
 end
-
-function Game.getWaterVertBase()
-	local mapModel = dereferencePointer(Game.Memory.water_model_pointer);
+-- B-Map Vert-Base
+function Game.getAlphaVertBase()
+	local mapModel = dereferencePointer(Game.Memory.alpha_model_pointer);
 	if isRDRAM(mapModel) then
 		return Game.getVertsFromModel(mapModel);
 	end

--- a/games/bt.lua
+++ b/games/bt.lua
@@ -7071,7 +7071,7 @@ function Game.getVertBase()
 	return gcmap.opaque.vertexBuffers[gcmap.opaque.vertexBufferIndex];
 end
 
-function Game.getWaterVertBase()
+function Game.getAlphaVertBase()
 	local gcmap = readGCMapStruct();
 	return gcmap.translucent.vertexBuffers[gcmap.translucent.vertexBufferIndex];
 end

--- a/lib/BanjoCommonFunctions.lua
+++ b/lib/BanjoCommonFunctions.lua
@@ -63,6 +63,7 @@ function Game.getFloorTriangleVertPosition(index)
 	return "Unknown";
 end
 
+-- A-Map Floor Triangle
 function Game.getFloorTriangleVertPositionRaw(index)
 	if type(index) ~= 'number' then
 		return;
@@ -84,6 +85,29 @@ function Game.getFloorTriangleVertPositionRaw(index)
 	end
 end
 
+-- B-Map Floor Triangle
+function Game.getAlphaFloorTriangleVertPositionRaw(index)
+	if type(index) ~= 'number' then
+		return;
+	end
+	if index < 0 or index > 2 then
+		return;
+	end
+	local floorObject = Game.getFloorObject();
+	if isRDRAM(floorObject) then
+		local vertIndex = mainmemory.read_u16_be(floorObject + 0x04 + index * 0x02);
+		local vertBase = Game.getAlphaVertBase();
+		if isRDRAM(vertBase) then
+			return {
+				x = mainmemory.read_s16_be(vertBase + (vertIndex * 0x10) + 0x00),
+				y = mainmemory.read_s16_be(vertBase + (vertIndex * 0x10) + 0x02),
+				z = mainmemory.read_s16_be(vertBase + (vertIndex * 0x10) + 0x04),
+			};
+		end
+	end
+end
+
+-- B-Map Water Triangle
 function Game.getWaterTriangleVertPositionRaw(index)
 	if type(index) ~= 'number' then
 		return;
@@ -94,7 +118,7 @@ function Game.getWaterTriangleVertPositionRaw(index)
 	local floorObject = Game.getFloorObject();
 	if isRDRAM(floorObject) then
 		local vertIndex = mainmemory.read_u16_be(floorObject + 0x10 + index * 0x02);
-		local vertBase = Game.getWaterVertBase();
+		local vertBase = Game.getAlphaVertBase();
 		if isRDRAM(vertBase) then
 			return {
 				x = mainmemory.read_s16_be(vertBase + (vertIndex * 0x10) + 0x00),
@@ -395,5 +419,19 @@ function printTri()
 	local vert1 = Game.getFloorTriangleVertPositionRaw(0);
 	local vert2 = Game.getFloorTriangleVertPositionRaw(1);
 	local vert3 = Game.getFloorTriangleVertPositionRaw(2);
+	print(vert1.x .." ".. vert1.y .." ".. vert1.z .." ".. vert2.x .." ".. vert2.y .." ".. vert2.z .." "..vert3.x .." ".. vert3.y .." ".. vert3.z);
+end
+
+function printAlphaTri()
+	local vert1 = Game.getAlphaFloorTriangleVertPositionRaw(0);
+	local vert2 = Game.getAlphaFloorTriangleVertPositionRaw(1);
+	local vert3 = Game.getAlphaFloorTriangleVertPositionRaw(2);
+	print(vert1.x .." ".. vert1.y .." ".. vert1.z .." ".. vert2.x .." ".. vert2.y .." ".. vert2.z .." "..vert3.x .." ".. vert3.y .." ".. vert3.z);
+end
+
+function printWaterTri()
+	local vert1 = Game.getWaterTriangleVertPositionRaw(0);
+	local vert2 = Game.getWaterTriangleVertPositionRaw(1);
+	local vert3 = Game.getWaterTriangleVertPositionRaw(2);
 	print(vert1.x .." ".. vert1.y .." ".. vert1.z .." ".. vert2.x .." ".. vert2.y .." ".. vert2.z .." "..vert3.x .." ".. vert3.y .." ".. vert3.z);
 end


### PR DESCRIPTION
Renamed some functions and variables from "water" to "alpha" because they actually refer to B-Model Data (which is not exclusively water-data, but also everything thats transparent). Also added printAlphaTri() and printWaterTri() to print triangle-data from transparent floors and from water-surfaces, to aid the BitClip Bruteforcer.