### PR TITLE
Add support for Donkey Kong Country 1 GBA & Small Fix for Bizhawk 2.9

### DIFF
--- a/ScriptHawk.lua
+++ b/ScriptHawk.lua
@@ -534,6 +534,9 @@ local supportedGames = {
 	["CF806FF2603640A748FCA5026DED28802F1F4A50"] = {moduleName="games.dk64", friendlyName="Donkey Kong 64 (USA)", version=1},
 	["F39476827CCF7F03707DE5D79949559A4DAC390B"] = {moduleName="games.dk64", friendlyName="Donkey Kong 64 (LodgeNet)", version=5},
 
+	-- Donkey Kong Country 1 (GBA)
+	["FCC62356A3B7157CA7DDA1398C9BF1AF1DD31265"] = {moduleName="games.GBA_dkc1", friendlyName="Donkey Kong Country (USA)", version=1},
+
 	-- Donkey Kong Country 2 (GBA)
 	["B0A4D59447C8D7C321BEA4DC7253B0F581129EDE"] = {moduleName="games.GBA_dkc2", friendlyName="Donkey Kong Country 2 (USA)", version=1},
 

--- a/games/GBA_dkc1.lua
+++ b/games/GBA_dkc1.lua
@@ -1,0 +1,143 @@
+if type(ScriptHawk) ~= "table" then
+	print("This script is not designed to run by itself");
+	print("Please run ScriptHawk.lua from the parent directory instead");
+	print("Thanks for using ScriptHawk :)");
+	return;
+end
+
+local Game = {
+	Memory = {
+        pos_ptr = {Domain = "IWRAM", Address = 0xE18},
+	},
+};
+
+local script_modes = {
+	"Disabled",
+};
+
+local script_mode_index = 1;
+local script_mode = script_modes[script_mode_index];
+
+--------------------
+-- Region/Version --
+--------------------
+
+function Game.detectVersion(romName, romHash)
+	ScriptHawk.dpad.joypad.enabled = false;
+	ScriptHawk.dpad.key.enabled = false;
+	return true;
+end
+
+--------------
+-- Position --
+--------------
+
+function Game.getXPosition()
+	local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+		return memory.read_s32_le(posInfo.Address, posInfo.Domain);
+	end
+	return 0;
+end
+
+function Game.getYPosition()
+	local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+		return memory.read_s32_le(posInfo.Address + 0x04, posInfo.Domain);
+	end
+	return 0;
+end
+
+function Game.colorYVelocity()
+	local yVelocity = Game.getYVelocity();
+	if yVelocity > 0 then
+		return colors.red;
+	end
+end
+
+function Game.setXPosition()
+	local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+		return memory.write_s32_le(posInfo.Address, posInfo.Domain);
+	end
+	return 0;
+end
+
+function Game.setYPosition()
+	local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+		return memory.write_s32_le(posInfo.Address + 0x04, posInfo.Domain);
+	end
+	return 0;
+end
+
+--------------
+-- Velocity --
+--------------
+
+function Game.getXVelocity()
+    local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+        posInfo.Address = posInfo.Address + 0x98;
+		local speedInfo = dereferencePointer(posInfo);
+        if speedInfo ~= nil then
+            return memory.read_s32_le(speedInfo.Address + 0x18, speedInfo.Domain);
+        end
+	end
+	return 0;
+end
+
+function Game.getYVelocity()
+    local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+        posInfo.Address = posInfo.Address + 0x98;
+		local speedInfo = dereferencePointer(posInfo);
+        if speedInfo ~= nil then
+            return memory.read_s32_le(speedInfo.Address + 0x1C, speedInfo.Domain);
+        end
+	end
+	return 0;
+end
+
+function Game.setXVelocity()
+    local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+        posInfo.Address = posInfo.Address + 0x98;
+		local speedInfo = dereferencePointer(posInfo);
+        if speedInfo ~= nil then
+            return memory.write_s32_le(speedInfo.Address + 0x18, speedInfo.Domain);
+        end
+	end
+	return 0;
+end
+
+function Game.setYVelocity()
+    local posInfo = dereferencePointer(Game.Memory.pos_ptr)
+	if posInfo ~= nil then
+        posInfo.Address = posInfo.Address + 0x98;
+		local speedInfo = dereferencePointer(posInfo);
+        if speedInfo ~= nil then
+            return memory.write_s32_le(speedInfo.Address + 0x1C, speedInfo.Domain);
+        end
+	end
+	return 0;
+end
+
+
+
+Game.OSD = {
+	{"X", category="position"},
+	{"Y", category="position"},
+	{"Separator"},
+	{"X Vel", Game.getXVelocity, category="speed"},
+	{"Y Vel", Game.getYVelocity, Game.colorYVelocity, category="speed"},
+	{"dY", category="positionStats"},
+	{"dXZ", category="positionStats"},
+	{"Separator"},
+	{"Max dY", category="positionStatsMore"},
+	{"Max dXZ", category="positionStatsMore"},
+	{"Odometer", category="positionStatsMore"},
+	{"Separator"},
+};
+
+return Game;

--- a/lib/LibScriptHawk.lua
+++ b/lib/LibScriptHawk.lua
@@ -202,7 +202,7 @@ function divisibleBy(number, divisor)
 end
 
 function angleBetweenPoints(x1, y1, x2, y2)
-	local angle = 180 * (math.atan2(x2 - x1, y2 - y1)) / math.pi;
+	local angle = 180 * (math.atan(x2 - x1, y2 - y1)) / math.pi;
 	return (angle + 360) % 360;
 end
 


### PR DESCRIPTION
Hi, some folks were working on a TAS for DKC1 GBA so i went ahead and added support for it here. The script is near identical to that of DKC2 GBA.

However, while working on this, i noticed starting from Bizhawk 2.9 (which upgraded the version of Lua), both DKC1 GBA and DKC2 GBA wouldn't work, with the following error in the console:

``` NLua.Exceptions.LuaScriptException: .\lib\LibScriptHawk.lua:205: attempt to call a nil value (field 'atan2') ```

It looks like starting Lua 5.3, the atan2 function got deprecated, instead recommending to uses the atan function with two parameters - https://www.lua.org/manual/5.3/manual.html#8.2

(For context, it looks like Bizhawk 2.8 uses Lua 5.1, while Bizhawk 2.9 uses Lua 5.4).

By replacing that function call with atan(), the error goes away and the scripts work on Bizhawk 2.9.
From what i can tell, on older versions of Lua, the atan function also accepts two arguments, because the code in this PR also seems to work on versions of Bizhawk as old as 1.11.5, at least for DKC1 GBA and DKC2 GBA. However, i am not 100% sure this doesn't break something else i'm not aware of, so please double check this!